### PR TITLE
Add server-side preference persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ After switching branches or pulling latest changes:
 33. Payments Reconciliation
 34. A lot more bug fixes from the version 14
 35. Offline invoices that fail to submit are saved as draft documents
+36. Column visibility and item selector settings are stored on the server and synced across devices while still working offline
 
 ### How to Install
 

--- a/posawesome/posawesome/api/__init__.py
+++ b/posawesome/posawesome/api/__init__.py
@@ -1,60 +1,53 @@
-# -*- coding: utf-8 -*-
 """Expose API functions for POS Awesome."""
 
-from .items import (
-    get_items,
-    get_items_groups,
-    get_items_details,
-    get_item_detail,
-    get_items_from_barcode,
-    get_item_attributes,
-)
-
 from .customers import (
-    get_customer_names,
-    get_customer_info,
     create_customer,
-    set_customer_info,
     get_customer_addresses,
-    make_address,
+    get_customer_info,
+    get_customer_names,
     get_sales_person_names,
+    make_address,
+    set_customer_info,
 )
-
 from .invoices import (
-    update_invoice,
-    submit_invoice,
     delete_invoice,
     get_draft_invoices,
     search_invoices_for_return,
+    submit_invoice,
+    update_invoice,
     validate_return_items,
 )
-
-from .shifts import (
-    get_opening_dialog_data,
-    create_opening_voucher,
-    check_opening_shift,
+from .items import (
+    get_item_attributes,
+    get_item_detail,
+    get_items,
+    get_items_details,
+    get_items_from_barcode,
+    get_items_groups,
 )
-
+from .offers import (
+    get_active_gift_coupons,
+    get_applicable_delivery_charges,
+    get_offers,
+    get_pos_coupon,
+)
 from .payments import (
     create_payment_request,
     get_available_credit,
 )
-
+from .preferences import load_user_preferences, save_user_preferences
 from .sales_orders import search_orders
-
-from .offers import (
-    get_pos_coupon,
-    get_active_gift_coupons,
-    get_offers,
-    get_applicable_delivery_charges,
+from .shifts import (
+    check_opening_shift,
+    create_opening_voucher,
+    get_opening_dialog_data,
 )
-
 from .utilities import (
-    get_version,
     get_app_branch,
-    get_selling_price_lists,
     get_app_info,
     get_language_options,
+    get_selling_price_lists,
     get_translation_dict,
+    get_version,
 )
 

--- a/posawesome/posawesome/api/preferences.py
+++ b/posawesome/posawesome/api/preferences.py
@@ -1,0 +1,32 @@
+"""APIs for persisting user preferences."""
+
+
+import json
+
+import frappe
+
+
+@frappe.whitelist()
+def save_user_preferences(key: str, prefs: str | dict):
+    """Save preferences for the current user."""
+    if isinstance(prefs, str):
+        try:
+            prefs = json.loads(prefs)
+        except Exception:
+            frappe.throw("Invalid preferences data")
+
+    frappe.defaults.set_user_default(f"posa_{key}", json.dumps(prefs))
+    return {"status": "ok"}
+
+
+@frappe.whitelist()
+def load_user_preferences(key: str) -> dict:
+    """Load preferences for the current user."""
+    data = frappe.defaults.get_user_default(f"posa_{key}")
+    if not data:
+        return {}
+    try:
+        return json.loads(data)
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "POSA Load Preferences Failed")
+        return {}

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -294,15 +294,39 @@ export default {
       this.show_column_selector = false;
     },
 
-    saveColumnPreferences() {
+    async saveColumnPreferences() {
       try {
-        localStorage.setItem('posawesome_selected_columns', JSON.stringify(this.selected_columns));
+        await frappe.call({
+          method: 'posawesome.posawesome.api.preferences.save_user_preferences',
+          args: {
+            key: 'column_preferences',
+            prefs: JSON.stringify(this.selected_columns),
+          },
+        });
       } catch (e) {
         console.error('Failed to save column preferences:', e);
       }
+      try {
+        localStorage.setItem('posawesome_selected_columns', JSON.stringify(this.selected_columns));
+      } catch (e) {
+        console.error('Failed to save column preferences locally:', e);
+      }
     },
 
-    loadColumnPreferences() {
+    async loadColumnPreferences() {
+      try {
+        const r = await frappe.call({
+          method: 'posawesome.posawesome.api.preferences.load_user_preferences',
+          args: { key: 'column_preferences' },
+        });
+        if (r.message) {
+          this.selected_columns = r.message;
+          localStorage.setItem('posawesome_selected_columns', JSON.stringify(this.selected_columns));
+          return;
+        }
+      } catch (e) {
+        console.error('Failed to load column preferences from server:', e);
+      }
       try {
         const saved = localStorage.getItem('posawesome_selected_columns');
         if (saved) {


### PR DESCRIPTION
## Summary
- add `preferences.py` API module for saving and loading user preferences
- expose new API functions in `posawesome.api.__init__`
- persist column and item selector settings via server endpoints with localStorage fallback
- note new behaviour in README

## Testing
- `ruff check posawesome/posawesome/api/preferences.py`
- `ruff check posawesome/posawesome/api/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6866b889af848329bc062d185a2c9258