### PR TITLE
Add theme settings mixin

### DIFF
--- a/posawesome/public/js/posapp/components/payments/Pay.vue
+++ b/posawesome/public/js/posapp/components/payments/Pay.vue
@@ -248,9 +248,10 @@ import Customer from "../pos/Customer.vue";
 import UpdateCustomer from "../pos/UpdateCustomer.vue";
 import { getOpeningStorage, setOpeningStorage, initPromise, saveOfflinePayment, syncOfflinePayments, getPendingOfflinePaymentCount, isOffline, getCustomerStorage } from "../../../offline/index.js";
 import { silentPrint } from "../../plugins/print.js";
+import { themeSettingsMixin } from '../../mixins/themeSettings.js';
 
 export default {
-  mixins: [format],
+  mixins: [format, themeSettingsMixin],
   data: function () {
     return {
       dialog: false,
@@ -1036,11 +1037,8 @@ export default {
       });
 
       return flt(invoiceTotal - paymentTotal);
+      }
     },
-    isDarkTheme() {
-      return this.$theme.current === 'dark';
-    }
-  },
 
   created() {
     this.syncPendingPayments();

--- a/posawesome/public/js/posapp/components/pos/Customer.vue
+++ b/posawesome/public/js/posapp/components/pos/Customer.vue
@@ -132,8 +132,10 @@
 <script>
 import UpdateCustomer from './UpdateCustomer.vue';
 import { getCustomerStorage, setCustomerStorage } from '../../../offline/index.js';
+import { themeSettingsMixin } from '../../mixins/themeSettings.js';
 
 export default {
+  mixins: [themeSettingsMixin],
   props: {
     pos_profile: Object
   },
@@ -156,10 +158,6 @@ export default {
   },
 
   computed: {
-    isDarkTheme() {
-      return this.$theme.current === 'dark';
-    },
-
     filteredCustomers() {
       const search = this.customerSearch.toLowerCase();
       let results = this.customers;

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -121,10 +121,11 @@ import itemMethods from "./invoiceItemMethods";
 import offerMethods from "./invoiceOfferMethods";
 import shortcutMethods from "./invoiceShortcuts";
 import { isOffline, saveCustomerBalance, getCachedCustomerBalance } from "../../../offline";
+import { themeSettingsMixin } from "../../mixins/themeSettings.js";
 
 export default {
   name: 'POSInvoice',
-  mixins: [format],
+  mixins: [format, themeSettingsMixin],
   data() {
     return {
       // POS profile settings
@@ -186,9 +187,7 @@ export default {
   },
   computed: {
     ...invoiceComputed,
-    isDarkTheme() {
-      return this.$theme.current === 'dark';
-    }
+    
   },
 
 

--- a/posawesome/public/js/posapp/components/pos/InvoiceSummary.vue
+++ b/posawesome/public/js/posapp/components/pos/InvoiceSummary.vue
@@ -133,7 +133,9 @@
 </template>
 
 <script>
+import { themeSettingsMixin } from '../../mixins/themeSettings.js';
 export default {
+  mixins: [themeSettingsMixin],
   props: {
     pos_profile: Object,
     total_qty: [Number, String],
@@ -159,24 +161,7 @@ export default {
     'open-returns',
     'print-draft',
     'show-payment'
-  ],
-  computed: {
-    isDarkTheme() {
-      return this.$theme?.current === 'dark';
-    },
-    hide_qty_decimals() {
-      try {
-        const saved = localStorage.getItem('posawesome_item_selector_settings');
-        if (saved) {
-          const opts = JSON.parse(saved);
-          return !!opts.hide_qty_decimals;
-        }
-      } catch (e) {
-        console.error('Failed to load item selector settings:', e);
-      }
-      return false;
-    }
-  }
+  ]
 }
 </script>
 

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -183,9 +183,10 @@ import _ from "lodash";
 import CameraScanner from './CameraScanner.vue';
 import { saveItemUOMs, getItemUOMs, getLocalStock, isOffline, initializeStockCache, getItemsStorage, setItemsStorage, getLocalStockCache, setLocalStockCache, initPromise, getCachedPriceListItems, savePriceListItems, updateLocalStockCache, isStockCacheReady, getCachedItemDetails, saveItemDetailsCache } from '../../../offline/index.js';
 import { responsiveMixin } from '../../mixins/responsive.js';
+import { themeSettingsMixin } from '../../mixins/themeSettings.js';
 
 export default {
-  mixins: [format, responsiveMixin],
+  mixins: [format, responsiveMixin, themeSettingsMixin],
   components: {
     CameraScanner,
   },
@@ -1685,9 +1686,6 @@ export default {
         }
         this.qty = parsed;
       }, 200),
-    },
-    isDarkTheme() {
-      return this.$theme.current === 'dark';
     },
     active_price_list() {
       return this.customer_price_list || (this.pos_profile && this.pos_profile.selling_price_list);

--- a/posawesome/public/js/posapp/components/pos/ItemsTable.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsTable.vue
@@ -201,8 +201,10 @@
 </template>
 
 <script>
+import { themeSettingsMixin } from '../../mixins/themeSettings.js';
 export default {
   name: 'ItemsTable',
+  mixins: [themeSettingsMixin],
   props: {
     headers: Array,
     items: Array,
@@ -245,21 +247,7 @@ export default {
         ? { style: 'background-color:#121212;color:#fff' }
         : {};
     },
-    isDarkTheme() {
-      return this.$theme.current === 'dark';
-    },
-    hide_qty_decimals() {
-      try {
-        const saved = localStorage.getItem('posawesome_item_selector_settings');
-        if (saved) {
-          const opts = JSON.parse(saved);
-          return !!opts.hide_qty_decimals;
-        }
-      } catch (e) {
-        console.error('Failed to load item selector settings:', e);
-      }
-      return false;
-    },
+
   },
   methods: {
     onDragOverFromSelector(event) {

--- a/posawesome/public/js/posapp/components/pos/NewAddress.vue
+++ b/posawesome/public/js/posapp/components/pos/NewAddress.vue
@@ -52,18 +52,15 @@
 </template>
 
 <script>
+import { themeSettingsMixin } from '../../mixins/themeSettings.js';
 
 export default {
+  mixins: [themeSettingsMixin],
   data: () => ({
     addressDialog: false,
     address: {},
     customer: '',
   }),
-  computed: {
-    isDarkTheme() {
-      return this.$theme.current === 'dark';
-    }
-  },
 
   methods: {
     close_dialog() {

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -398,10 +398,11 @@ import {
 
 import generateOfflineInvoiceHTML from "../../../offline_print_template";
 import { silentPrint } from "../../plugins/print.js";
+import { themeSettingsMixin } from '../../mixins/themeSettings.js';
 
 export default {
   // Using format mixin for shared formatting methods
-  mixins: [format],
+  mixins: [format, themeSettingsMixin],
   data() {
     return {
       loading: false, // UI loading state
@@ -570,9 +571,6 @@ export default {
       return this.pos_settings?.invoice_fields?.some(
         (el) => el.fieldtype === "Button" && el.fieldname === "request_for_payment"
       ) || false;
-    },
-    isDarkTheme() {
-      return this.$theme.current === 'dark';
     }
   },
   watch: {

--- a/posawesome/public/js/posapp/components/pos/PosCoupons.vue
+++ b/posawesome/public/js/posapp/components/pos/PosCoupons.vue
@@ -44,8 +44,10 @@
 </template>
 
 <script>
+import { themeSettingsMixin } from '../../mixins/themeSettings.js';
 
 export default {
+  mixins: [themeSettingsMixin],
   data: () => ({
     loading: false,
     pos_profile: '',
@@ -68,9 +70,6 @@ export default {
     },
     appliedCouponsCount() {
       return this.posa_coupons.filter((el) => !!el.applied).length;
-    },
-    isDarkTheme() {
-      return this.$theme?.current === 'dark';
     },
   },
 

--- a/posawesome/public/js/posapp/components/pos/PosOffers.vue
+++ b/posawesome/public/js/posapp/components/pos/PosOffers.vue
@@ -55,8 +55,9 @@
 <script>
 
 import format from '../../format';
+import { themeSettingsMixin } from '../../mixins/themeSettings.js';
 export default {
-  mixins: [format],
+  mixins: [format, themeSettingsMixin],
   data: () => ({
     loading: false,
     pos_profile: '',
@@ -80,9 +81,6 @@ export default {
     },
     appliedOffersCount() {
       return this.pos_offers.filter((el) => !!el.offer_applied).length;
-    },
-    isDarkTheme() {
-      return this.$theme?.current === 'dark';
     },
   },
 

--- a/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
+++ b/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
@@ -46,7 +46,9 @@
 </template>
 
 <script>
+import { themeSettingsMixin } from '../../mixins/themeSettings.js';
 export default {
+  mixins: [themeSettingsMixin],
   props: {
     pos_profile: Object,
     posting_date_display: String,
@@ -60,11 +62,6 @@ export default {
       internal_posting_date_display: this.posting_date_display,
       internal_price_list: this.priceList,
     };
-  },
-  computed: {
-    isDarkTheme() {
-      return this.$theme?.current === 'dark';
-    }
   },
   watch: {
     posting_date_display(val) {

--- a/posawesome/public/js/posapp/components/pos/Returns.vue
+++ b/posawesome/public/js/posapp/components/pos/Returns.vue
@@ -138,9 +138,10 @@
 
 <script>
 import format from '../../format';
+import { themeSettingsMixin } from '../../mixins/themeSettings.js';
 
 export default {
-  mixins: [format],
+  mixins: [format, themeSettingsMixin],
   data: () => ({
     invoicesDialog: false,
     singleSelect: true,
@@ -191,11 +192,6 @@ export default {
       },
     ],
   }),
-  computed: {
-    isDarkTheme() {
-      return this.$theme?.current === 'dark';
-    }
-  },
   watch: {
     from_date() {
       this.formatFromDate();

--- a/posawesome/public/js/posapp/components/pos/UpdateCustomer.vue
+++ b/posawesome/public/js/posapp/components/pos/UpdateCustomer.vue
@@ -125,8 +125,10 @@
 
 <script>
 import { isOffline, saveOfflineCustomer } from '../../../offline/index.js';
+import { themeSettingsMixin } from '../../mixins/themeSettings.js';
 
 export default {
+  mixins: [themeSettingsMixin],
   data: () => ({
     customerDialog: false,
     confirmDialog: false,
@@ -243,11 +245,7 @@ export default {
       }
     }
   },
-  computed: {
-    isDarkTheme() {
-      return this.$theme.current === 'dark';
-    }
-  },
+  
   methods: {
     // Add a new method to update calendar date
     updateCalendarDate(day, month, year) {

--- a/posawesome/public/js/posapp/mixins/themeSettings.js
+++ b/posawesome/public/js/posapp/mixins/themeSettings.js
@@ -1,0 +1,19 @@
+export const themeSettingsMixin = {
+  computed: {
+    isDarkTheme() {
+      return this.$theme?.current === 'dark';
+    },
+    hide_qty_decimals() {
+      try {
+        const saved = localStorage.getItem('posawesome_item_selector_settings');
+        if (saved) {
+          const opts = JSON.parse(saved);
+          return !!opts.hide_qty_decimals;
+        }
+      } catch (e) {
+        console.error('Failed to load item selector settings:', e);
+      }
+      return false;
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add `themeSettingsMixin` for common theme logic
- use the mixin in POS components
- drop duplicate `isDarkTheme`/`hide_qty_decimals` logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866b885ebf88329a4f29c6b93842f1c