### PR TITLE
refactor: replace directional CSS properties with logical equivalents

### DIFF
--- a/posawesome/public/css/responsive.css
+++ b/posawesome/public/css/responsive.css
@@ -160,82 +160,82 @@ body {
 
 /* Directional spacing utilities */
 .dynamic-px-xs {
-	padding-left: var(--dynamic-xs);
-	padding-right: var(--dynamic-xs);
+        padding-inline-start: var(--dynamic-xs);
+        padding-inline-end: var(--dynamic-xs);
 }
 
 .dynamic-px-sm {
-	padding-left: var(--dynamic-sm);
-	padding-right: var(--dynamic-sm);
+        padding-inline-start: var(--dynamic-sm);
+        padding-inline-end: var(--dynamic-sm);
 }
 
 .dynamic-px-md {
-	padding-left: var(--dynamic-md);
-	padding-right: var(--dynamic-md);
+        padding-inline-start: var(--dynamic-md);
+        padding-inline-end: var(--dynamic-md);
 }
 
 .dynamic-px-lg {
-	padding-left: var(--dynamic-lg);
-	padding-right: var(--dynamic-lg);
+        padding-inline-start: var(--dynamic-lg);
+        padding-inline-end: var(--dynamic-lg);
 }
 
 .dynamic-px-xl {
-	padding-left: var(--dynamic-xl);
-	padding-right: var(--dynamic-xl);
+        padding-inline-start: var(--dynamic-xl);
+        padding-inline-end: var(--dynamic-xl);
 }
 
 .dynamic-py-xs {
-	padding-top: var(--dynamic-xs);
-	padding-bottom: var(--dynamic-xs);
+        padding-top: var(--dynamic-xs);
+        padding-bottom: var(--dynamic-xs);
 }
 
 .dynamic-py-sm {
-	padding-top: var(--dynamic-sm);
-	padding-bottom: var(--dynamic-sm);
+        padding-top: var(--dynamic-sm);
+        padding-bottom: var(--dynamic-sm);
 }
 
 .dynamic-py-md {
-	padding-top: var(--dynamic-md);
-	padding-bottom: var(--dynamic-md);
+        padding-top: var(--dynamic-md);
+        padding-bottom: var(--dynamic-md);
 }
 
 .dynamic-py-lg {
-	padding-top: var(--dynamic-lg);
-	padding-bottom: var(--dynamic-lg);
+        padding-top: var(--dynamic-lg);
+        padding-bottom: var(--dynamic-lg);
 }
 
 .dynamic-py-xl {
-	padding-top: var(--dynamic-xl);
-	padding-bottom: var(--dynamic-xl);
+        padding-top: var(--dynamic-xl);
+        padding-bottom: var(--dynamic-xl);
 }
 
 .dynamic-mx-xs {
-	margin-left: var(--dynamic-xs);
-	margin-right: var(--dynamic-xs);
+        margin-inline-start: var(--dynamic-xs);
+        margin-inline-end: var(--dynamic-xs);
 }
 
 .dynamic-mx-sm {
-	margin-left: var(--dynamic-sm);
-	margin-right: var(--dynamic-sm);
+        margin-inline-start: var(--dynamic-sm);
+        margin-inline-end: var(--dynamic-sm);
 }
 
 .dynamic-mx-md {
-	margin-left: var(--dynamic-md);
-	margin-right: var(--dynamic-md);
+        margin-inline-start: var(--dynamic-md);
+        margin-inline-end: var(--dynamic-md);
 }
 
 .dynamic-mx-lg {
-	margin-left: var(--dynamic-lg);
-	margin-right: var(--dynamic-lg);
+        margin-inline-start: var(--dynamic-lg);
+        margin-inline-end: var(--dynamic-lg);
 }
 
 .dynamic-mx-xl {
-	margin-left: var(--dynamic-xl);
-	margin-right: var(--dynamic-xl);
+        margin-inline-start: var(--dynamic-xl);
+        margin-inline-end: var(--dynamic-xl);
 }
 
 .dynamic-my-xs {
-	margin-top: var(--dynamic-xs);
+        margin-top: var(--dynamic-xs);
 	margin-bottom: var(--dynamic-xs);
 }
 

--- a/posawesome/public/js/posapp/components/OfflineInvoices.vue
+++ b/posawesome/public/js/posapp/components/OfflineInvoices.vue
@@ -261,8 +261,8 @@ export default {
 	content: "";
 	position: absolute;
 	top: 0;
-	left: 0;
-	right: 0;
+        inset-inline-start: 0;
+        inset-inline-end: 0;
 	height: 4px;
 	background: linear-gradient(90deg, var(--primary-start) 0%, var(--primary-end) 100%);
 }

--- a/posawesome/public/js/posapp/components/navbar/AboutDialog.vue
+++ b/posawesome/public/js/posapp/components/navbar/AboutDialog.vue
@@ -157,8 +157,8 @@ export default {
 	content: "";
 	position: absolute;
 	top: 0;
-	left: 0;
-	right: 0;
+        inset-inline-start: 0;
+        inset-inline-end: 0;
 	height: 3px;
 	background: linear-gradient(90deg, #1976d2 0%, #42a5f5 100%);
 }
@@ -167,7 +167,7 @@ export default {
 	display: flex;
 	align-items: center;
 	gap: 16px;
-	padding-right: 60px;
+        padding-inline-end: 60px;
 	/* Space for close button */
 }
 
@@ -351,7 +351,7 @@ export default {
 
 	.header-content-improved {
 		gap: 12px;
-		padding-right: 50px;
+                padding-inline-end: 50px;
 	}
 
 	.content-container-improved {

--- a/posawesome/public/js/posapp/components/navbar/CacheUsageMeter.vue
+++ b/posawesome/public/js/posapp/components/navbar/CacheUsageMeter.vue
@@ -188,7 +188,7 @@ export default {
 	background: #e3f2fd;
 	border-radius: 4px;
 	overflow: hidden;
-	margin-right: 6px;
+        margin-inline-end: 6px;
 }
 .cache-bar-fill {
 	height: 100%;

--- a/posawesome/public/js/posapp/components/navbar/CpuGadget.vue
+++ b/posawesome/public/js/posapp/components/navbar/CpuGadget.vue
@@ -247,7 +247,7 @@ const peakPercent = computed(() => Math.round(Math.min(peakLag.value, 100)));
 	background: #e3f2fd;
 	border-radius: 4px;
 	overflow: hidden;
-	margin-right: 6px;
+        margin-inline-end: 6px;
 }
 .cpu-bar-fill {
 	height: 100%;
@@ -318,7 +318,7 @@ const peakPercent = computed(() => Math.round(Math.min(peakLag.value, 100)));
 	width: 10px;
 	height: 10px;
 	border-radius: 50%;
-	margin-right: 4px;
+        margin-inline-end: 4px;
 }
 .legend-dot.client {
 	background: #4caf50;

--- a/posawesome/public/js/posapp/components/navbar/NavbarAppBar.vue
+++ b/posawesome/public/js/posapp/components/navbar/NavbarAppBar.vue
@@ -263,16 +263,16 @@ export default {
 .loading-container {
 	position: absolute;
 	bottom: 0;
-	left: 0;
-	right: 0;
+        inset-inline-start: 0;
+        inset-inline-end: 0;
 	z-index: 1000;
 }
 
 .glass-card {
 	position: absolute;
 	top: -40px;
-	left: 12px;
-	right: 12px;
+        inset-inline-start: 12px;
+        inset-inline-end: 12px;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;

--- a/posawesome/public/js/posapp/components/navbar/NavbarDrawer.vue
+++ b/posawesome/public/js/posapp/components/navbar/NavbarDrawer.vue
@@ -144,7 +144,7 @@ export default {
 
 /* Styling for the company name text within the drawer header */
 .drawer-company {
-	margin-left: 12px;
+        margin-inline-start: 12px;
 	flex: 1;
 	font-weight: 500;
 	font-size: 1rem;
@@ -160,7 +160,7 @@ export default {
 
 /* Styling for the title text of navigation drawer list items */
 .drawer-item-title {
-	margin-left: 8px;
+        margin-inline-start: 8px;
 	font-weight: 500;
 	font-size: 0.95rem;
 	color: #000000 !important;

--- a/posawesome/public/js/posapp/components/navbar/NavbarMenu.vue
+++ b/posawesome/public/js/posapp/components/navbar/NavbarMenu.vue
@@ -422,8 +422,8 @@ export default {
 <style scoped>
 /* Compact Menu Button - Better Navbar Integration */
 .menu-btn-compact {
-	margin-left: 8px;
-	margin-right: 4px;
+        margin-inline-start: 8px;
+        margin-inline-end: 4px;
 	padding: 6px 16px;
 	border-radius: 20px;
 	font-weight: 600;
@@ -500,8 +500,8 @@ export default {
 	content: "";
 	position: absolute;
 	top: 0;
-	left: 0;
-	right: 0;
+        inset-inline-start: 0;
+        inset-inline-end: 0;
 	bottom: 0;
 	background: transparent;
 	transition: all 0.3s ease;
@@ -659,7 +659,7 @@ export default {
 	}
 
 	.menu-btn-compact {
-		margin-left: 6px;
+                margin-inline-start: 6px;
 		padding: 5px 14px;
 		min-width: 85px;
 		height: 34px;

--- a/posawesome/public/js/posapp/components/navbar/ServerUsageGadget.vue
+++ b/posawesome/public/js/posapp/components/navbar/ServerUsageGadget.vue
@@ -275,7 +275,7 @@ const peakPercent = computed(() => Math.round(Math.min(peakLag.value, 100)));
 	background: #e3f2fd;
 	border-radius: 4px;
 	overflow: hidden;
-	margin-right: 6px;
+        margin-inline-end: 6px;
 }
 .cpu-bar-fill {
 	height: 100%;
@@ -346,7 +346,7 @@ const peakPercent = computed(() => Math.round(Math.min(peakLag.value, 100)));
 	width: 10px;
 	height: 10px;
 	border-radius: 50%;
-	margin-right: 4px;
+        margin-inline-end: 4px;
 }
 .legend-dot.client {
 	background: #4caf50;

--- a/posawesome/public/js/posapp/components/navbar/StatusIndicator.vue
+++ b/posawesome/public/js/posapp/components/navbar/StatusIndicator.vue
@@ -183,7 +183,7 @@ export default {
 	align-items: center;
 	gap: 8px;
 	/* Reduced gap */
-	margin-right: 8px;
+        margin-inline-end: 8px;
 	/* Reduced margin */
 }
 
@@ -236,7 +236,7 @@ export default {
 	}
 
 	.status-section-enhanced {
-		margin-right: 4px;
+                margin-inline-end: 4px;
 		/* Further reduced for mobile */
 	}
 }

--- a/posawesome/public/js/posapp/components/pos/CameraScanner.vue
+++ b/posawesome/public/js/posapp/components/pos/CameraScanner.vue
@@ -131,23 +131,23 @@
 }
 
 .scanning-overlay {
-	position: absolute;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	pointer-events: none;
-	z-index: 10;
+        position: absolute;
+        top: 0;
+        inset-inline-start: 0;
+        inset-inline-end: 0;
+        bottom: 0;
+        pointer-events: none;
+        z-index: 10;
 }
 
 .scan-line {
-	position: absolute;
-	top: 50%;
-	left: 10%;
-	right: 10%;
-	height: 2px;
-	background: linear-gradient(90deg, transparent, #4caf50, transparent);
-	animation: scan 2s linear infinite;
+        position: absolute;
+        top: 50%;
+        inset-inline-start: 10%;
+        inset-inline-end: 10%;
+        height: 2px;
+        background: linear-gradient(90deg, transparent, #4caf50, transparent);
+        animation: scan 2s linear infinite;
 }
 
 @keyframes scan {
@@ -161,11 +161,11 @@
 }
 
 .scan-corners {
-	position: absolute;
-	top: 20%;
-	left: 20%;
-	right: 20%;
-	bottom: 20%;
+        position: absolute;
+        top: 20%;
+        inset-inline-start: 20%;
+        inset-inline-end: 20%;
+        bottom: 20%;
 }
 
 .corner {
@@ -176,31 +176,31 @@
 }
 
 .corner.top-left {
-	top: 0;
-	left: 0;
-	border-right: none;
-	border-bottom: none;
+        top: 0;
+        inset-inline-start: 0;
+        border-right: none;
+        border-bottom: none;
 }
 
 .corner.top-right {
-	top: 0;
-	right: 0;
-	border-left: none;
-	border-bottom: none;
+        top: 0;
+        inset-inline-end: 0;
+        border-left: none;
+        border-bottom: none;
 }
 
 .corner.bottom-left {
-	bottom: 0;
-	left: 0;
-	border-right: none;
-	border-top: none;
+        bottom: 0;
+        inset-inline-start: 0;
+        border-right: none;
+        border-top: none;
 }
 
 .corner.bottom-right {
-	bottom: 0;
-	right: 0;
-	border-left: none;
-	border-top: none;
+        bottom: 0;
+        inset-inline-end: 0;
+        border-left: none;
+        border-top: none;
 }
 
 .status-messages {

--- a/posawesome/public/js/posapp/components/pos/Customer.vue
+++ b/posawesome/public/js/posapp/components/pos/Customer.vue
@@ -91,7 +91,7 @@
 .customer-input-wrapper {
 	width: 100%;
 	max-width: 100%;
-	padding-right: 1.5rem;
+        padding-inline-end: 1.5rem;
 	/* Elegant space at the right edge */
 	box-sizing: border-box;
 	display: flex;

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -1220,7 +1220,7 @@ export default {
 	font-size: 1.5rem;
 	font-weight: bold;
 	color: var(--primary-start);
-	margin-left: var(--dynamic-xs);
+        margin-inline-start: var(--dynamic-xs);
 }
 
 /* Red border and label for return mode card */
@@ -1237,7 +1237,7 @@ export default {
 	content: "RETURN";
 	position: absolute;
 	top: 0;
-	right: 0;
+        inset-inline-end: 0;
 	background-color: rgb(var(--v-theme-error));
 	color: white;
 	padding: 4px 12px;
@@ -1290,7 +1290,7 @@ export default {
 	border-radius: 8px 8px 0 0;
 	position: absolute;
 	top: 0;
-	right: 0;
+        inset-inline-end: 0;
 	transform: translateY(-100%);
 }
 

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -2165,7 +2165,7 @@ export default {
           <div class="item-option p-3 mb-2 border rounded cursor-pointer" data-item-index="${index}" style="border: 1px solid #ddd; cursor: pointer;">
             <div class="d-flex align-items-center">
               <img src="${item.image || "/assets/posawesome/js/posapp/components/pos/placeholder-image.png"}"
-                   style="width: 50px; height: 50px; object-fit: cover; margin-right: 15px;" />
+                   style="width: 50px; height: 50px; object-fit: cover; margin-inline-end: 15px;" />
               <div>
                 <div class="font-weight-bold">${item.item_name}</div>
                 <div class="text-muted small">${item.item_code}</div>

--- a/posawesome/public/js/posapp/components/pos/ItemsTable.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsTable.vue
@@ -833,7 +833,7 @@ export default {
 }
 
 .action-panel-icon {
-	margin-right: 8px;
+        margin-inline-end: 8px;
 	color: var(--primary-color, #1976d2);
 }
 
@@ -874,7 +874,7 @@ export default {
 }
 
 .item-action-btn .action-label {
-	margin-left: 8px;
+        margin-inline-start: 8px;
 	font-weight: 500;
 	display: none;
 }
@@ -1025,14 +1025,14 @@ export default {
 	content: "";
 	position: absolute;
 	bottom: -2px;
-	left: 0;
+        inset-inline-start: 0;
 	width: 40px;
 	height: 2px;
 	background: linear-gradient(90deg, var(--primary-color, #1976d2), transparent);
 }
 
 .section-icon {
-	margin-right: 10px;
+        margin-inline-end: 10px;
 	color: var(--primary-color, #1976d2);
 	background: rgba(25, 118, 210, 0.1);
 	padding: 6px;
@@ -1114,7 +1114,7 @@ export default {
 
 .currency-symbol {
 	opacity: 0.7;
-	margin-right: 2px;
+        margin-inline-end: 2px;
 	font-size: 0.85em;
 }
 

--- a/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
+++ b/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
@@ -574,7 +574,7 @@ export default {
 	}
 
 	.action-btn-compact {
-		margin-left: 4px;
+                margin-inline-start: 4px;
 		padding: 6px 10px;
 		min-width: 60px;
 	}

--- a/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
+++ b/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
@@ -172,6 +172,6 @@ export default {
 
 /* Increase right padding to accommodate both icons */
 .posting-date-input :deep(.dp__input) {
-	padding-right: calc(30px + var(--dp-input-icon-padding));
+        padding-inline-end: calc(30px + var(--dp-input-icon-padding));
 }
 </style>


### PR DESCRIPTION
## Summary
- switch margin and padding utilities in responsive.css to logical inline properties
- replace left/right positioning with inset-inline-* and update margins in Vue components
- remove all remaining margin-left/margin-right/padding-left/padding-right uses across project

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_689a3753fe308329bc0cc59149b1cfce