### PR TITLE
refactor: use logical margin utilities

### DIFF
--- a/posawesome/public/js/posapp/components/navbar/CacheUsageMeter.vue
+++ b/posawesome/public/js/posapp/components/navbar/CacheUsageMeter.vue
@@ -16,7 +16,7 @@
 			</template>
 			<div class="cache-tooltip-content">
 				<div class="cache-tooltip-title">
-					<v-icon size="14" color="info" class="mr-1">mdi-database-clock</v-icon>
+                                        <v-icon size="14" color="info" class="me-1">mdi-database-clock</v-icon>
 					{{ __("Cache Usage") }}
 				</div>
 				<v-divider class="my-2" />
@@ -35,15 +35,15 @@
 				<div v-if="!cacheUsageLoading">
 					<div class="cache-tooltip-section-title mb-1">{{ __("Breakdown") }}</div>
 					<div class="cache-tooltip-detail">
-						<v-icon size="14" color="info" class="mr-1">mdi-database-clock</v-icon
+                                                <v-icon size="14" color="info" class="me-1">mdi-database-clock</v-icon
 						>{{ __("Total Size") }}: <b>{{ formatBytes(cacheUsageDetails.total) }}</b>
 					</div>
 					<div class="cache-tooltip-detail">
-						<v-icon size="14" color="info" class="mr-1">mdi-database</v-icon
+                                                <v-icon size="14" color="info" class="me-1">mdi-database</v-icon
 						>{{ __("IndexedDB") }}: <b>{{ formatBytes(cacheUsageDetails.indexedDB) }}</b>
 					</div>
 					<div class="cache-tooltip-detail">
-						<v-icon size="14" color="info" class="mr-1">mdi-folder</v-icon
+                                                <v-icon size="14" color="info" class="me-1">mdi-folder</v-icon
 						>{{ __("localStorage") }}: <b>{{ formatBytes(cacheUsageDetails.localStorage) }}</b>
 					</div>
 				</div>
@@ -52,19 +52,19 @@
 				</div>
 				<v-divider class="my-2" />
 				<div v-if="cacheUsage >= 80" class="cache-tooltip-warning">
-					<v-icon size="14" color="error" class="mr-1">mdi-alert</v-icon>
+                                        <v-icon size="14" color="error" class="me-1">mdi-alert</v-icon>
 					{{ __("Warning: High cache usage may affect performance.") }}
 				</div>
 				<div class="cache-tooltip-tip mt-2">
-					<v-icon size="14" color="primary" class="mr-1">mdi-lightbulb-on-outline</v-icon>
+                                        <v-icon size="14" color="primary" class="me-1">mdi-lightbulb-on-outline</v-icon>
 					{{ __("Tip: Clear cache regularly to free up space and keep the app fast.") }}
 				</div>
 				<div class="cache-tooltip-explanation mt-2">
-					<v-icon size="14" color="info" class="mr-1">mdi-database-clock</v-icon>
+                                        <v-icon size="14" color="info" class="me-1">mdi-database-clock</v-icon>
 					{{ __("The app stores data locally for offline use. This is called cache.") }}
 				</div>
 				<div class="cache-tooltip-action mt-2">
-					<v-icon size="14" class="mr-1">mdi-refresh</v-icon>
+                                        <v-icon size="14" class="me-1">mdi-refresh</v-icon>
 					{{ __("Click to refresh") }}
 				</div>
 			</div>
@@ -188,7 +188,7 @@ export default {
 	background: #e3f2fd;
 	border-radius: 4px;
 	overflow: hidden;
-	margin-right: 6px;
+        margin-inline-end: 6px;
 }
 .cache-bar-fill {
 	height: 100%;

--- a/posawesome/public/js/posapp/components/navbar/CpuGadget.vue
+++ b/posawesome/public/js/posapp/components/navbar/CpuGadget.vue
@@ -10,7 +10,7 @@
 			<div class="cpu-tooltip-content">
 				<div class="cpu-tooltip-title">{{ __("CPU Load") }}</div>
 				<div class="cpu-tooltip-peak mb-1">
-					<v-icon size="14" color="success" class="mr-1">mdi-arrow-up-bold</v-icon>
+					<v-icon size="14" color="success" class="me-1">mdi-arrow-up-bold</v-icon>
 					{{ __("Peak:") }}
 					<b>{{ peakLag.toFixed(1) }} ms</b>
 					({{ peakPercent }}%)
@@ -36,7 +36,7 @@
 					{{ __("Current Event Loop Lag:") }} <b>{{ cpuLag.toFixed(1) }}</b> ms
 				</div>
 				<div v-if="cpuLag >= 80" class="cpu-tooltip-warning">
-					<v-icon size="14" color="error" class="mr-1">mdi-alert</v-icon>
+					<v-icon size="14" color="error" class="me-1">mdi-alert</v-icon>
 					{{ __("Warning: High lag may indicate heavy processing or browser slowness.") }}
 				</div>
 				<div v-if="serverLoading" class="cpu-tooltip-detail">
@@ -47,14 +47,14 @@
 					<div class="cpu-tooltip-detail">
 						{{ __("Server CPU Usage:") }}
 						<b>{{ serverCpu !== null ? serverCpu.toFixed(1) + "%" : "N/A" }}</b>
-						<span class="ml-2"
+						<span class="ms-2"
 							>{{ __("Peak Server:") }} <b>{{ serverPeak.toFixed(1) }}%</b></span
 						>
 					</div>
 					<div class="cpu-tooltip-detail">
 						{{ __("Server Memory Usage:") }}
 						<b>{{ serverMemory !== null ? serverMemory.toFixed(1) + "%" : "N/A" }}</b>
-						<span class="ml-2"
+						<span class="ms-2"
 							>{{ __("Peak Memory:") }} <b>{{ serverMemoryPeak.toFixed(1) }}%</b></span
 						>
 					</div>
@@ -74,10 +74,10 @@
 					</div>
 					<div class="cpu-tooltip-detail">
 						{{ __("Total:") }} <b>{{ formatBytes(memoryTotal) }}</b>
-						<span class="ml-2"
+						<span class="ms-2"
 							>{{ __("Used:") }} <b>{{ formatBytes(memoryUsed) }}</b></span
 						>
-						<span class="ml-2"
+						<span class="ms-2"
 							>{{ __("Available:") }} <b>{{ formatBytes(memoryAvailable) }}</b></span
 						>
 					</div>
@@ -86,15 +86,15 @@
 					</div>
 				</div>
 				<div class="cpu-tooltip-tip mt-2">
-					<v-icon size="14" color="primary" class="mr-1">mdi-lightbulb-on-outline</v-icon>
+					<v-icon size="14" color="primary" class="me-1">mdi-lightbulb-on-outline</v-icon>
 					{{ __("Tip: Close unused tabs or apps to reduce lag.") }}
 				</div>
 				<div class="cpu-tooltip-explanation mt-2">
-					<v-icon size="14" color="info" class="mr-1">mdi-chip</v-icon>
+					<v-icon size="14" color="info" class="me-1">mdi-chip</v-icon>
 					{{ __("Event-loop lag measures how busy your browser is. Lower is better.") }}
 				</div>
 				<div class="cpu-tooltip-action mt-2">
-					<v-icon size="14" class="mr-1">mdi-refresh</v-icon>
+					<v-icon size="14" class="me-1">mdi-refresh</v-icon>
 					{{ __("Updates automatically") }}
 				</div>
 			</div>
@@ -247,7 +247,7 @@ const peakPercent = computed(() => Math.round(Math.min(peakLag.value, 100)));
 	background: #e3f2fd;
 	border-radius: 4px;
 	overflow: hidden;
-	margin-right: 6px;
+	margin-inline-end: 6px;
 }
 .cpu-bar-fill {
 	height: 100%;
@@ -318,7 +318,7 @@ const peakPercent = computed(() => Math.round(Math.min(peakLag.value, 100)));
 	width: 10px;
 	height: 10px;
 	border-radius: 50%;
-	margin-right: 4px;
+	margin-inline-end: 4px;
 }
 .legend-dot.client {
 	background: #4caf50;

--- a/posawesome/public/js/posapp/components/navbar/DatabaseUsageGadget.vue
+++ b/posawesome/public/js/posapp/components/navbar/DatabaseUsageGadget.vue
@@ -9,7 +9,7 @@
 			</template>
 			<div class="db-tooltip-content p-3 min-w-[220px]">
 				<div class="db-tooltip-title flex items-center font-semibold text-[14px] mb-2">
-					<v-icon size="16" color="info" class="mr-1">mdi-database-settings</v-icon>
+					<v-icon size="16" color="info" class="me-1">mdi-database-settings</v-icon>
 					{{ __("Database Health") }}
 				</div>
 				<v-divider class="my-2" />
@@ -28,45 +28,45 @@
 						</svg>
 					</div>
 					<div class="db-tooltip-detail flex items-center mb-1">
-						<v-icon size="14" color="info" class="mr-1">mdi-database-settings</v-icon>
+						<v-icon size="14" color="info" class="me-1">mdi-database-settings</v-icon>
 						<b>{{ dbStats.db_engine }}</b>
-						<span class="ml-2">{{ dbStats.db_version }}</span>
+						<span class="ms-2">{{ dbStats.db_version }}</span>
 					</div>
 					<v-divider class="my-2" />
 					<div class="db-tooltip-section-title mb-1">{{ __("Usage Stats") }}</div>
 					<div class="db-tooltip-detail flex items-center mb-1">
-						<v-icon size="14" color="info" class="mr-1">mdi-database</v-icon>
+						<v-icon size="14" color="info" class="me-1">mdi-database</v-icon>
 						{{ __("Size:") }} <b>{{ formattedDbSize }}</b>
-						<span class="ml-2 flex items-center"
-							><v-icon size="14" color="info" class="mr-1">mdi-table</v-icon
+						<span class="ms-2 flex items-center"
+							><v-icon size="14" color="info" class="me-1">mdi-table</v-icon
 							>{{ __("Tables:") }} <b>{{ dbStats.db_table_count }}</b></span
 						>
-						<span class="ml-2 flex items-center"
-							><v-icon size="14" color="info" class="mr-1">mdi-format-list-numbered</v-icon
+						<span class="ms-2 flex items-center"
+							><v-icon size="14" color="info" class="me-1">mdi-format-list-numbered</v-icon
 							>{{ __("Rows:") }} <b>{{ dbStats.db_total_rows }}</b></span
 						>
 					</div>
 					<div class="db-tooltip-detail flex items-center mb-1">
-						<v-icon size="14" color="info" class="mr-1">mdi-connection</v-icon>
+						<v-icon size="14" color="info" class="me-1">mdi-connection</v-icon>
 						{{ __("Connections:") }} <b>{{ dbStats.db_connections }}</b>
-						<span class="ml-2 flex items-center"
-							><v-icon size="14" color="warning" class="mr-1">mdi-timer-sand</v-icon
+						<span class="ms-2 flex items-center"
+							><v-icon size="14" color="warning" class="me-1">mdi-timer-sand</v-icon
 							>{{ __("Slow Queries:") }} <b>{{ dbStats.db_slow_queries }}</b></span
 						>
 					</div>
 					<v-divider class="my-2" />
 					<div v-if="dbStats.db_top_tables && dbStats.db_top_tables.length">
 						<div class="db-tooltip-section-title mb-1 flex items-center">
-							<v-icon size="14" color="info" class="mr-1">mdi-database-outline</v-icon>
+							<v-icon size="14" color="info" class="me-1">mdi-database-outline</v-icon>
 							{{ __("Top Tables") }}
 						</div>
-						<ul class="db-top-tables ml-2">
+						<ul class="db-top-tables ms-2">
 							<li
 								v-for="t in dbStats.db_top_tables"
 								:key="t.name"
 								class="flex items-center mb-1"
 							>
-								<v-icon size="12" color="info" class="mr-1">mdi-table</v-icon>
+								<v-icon size="12" color="info" class="me-1">mdi-table</v-icon>
 								<b>{{ t.name }}</b
 								>: {{ formatBytes(t.size) }}
 							</li>
@@ -75,11 +75,11 @@
 				</div>
 				<v-divider class="my-2" />
 				<div class="db-tooltip-tip mt-2 flex items-center">
-					<v-icon size="14" color="primary" class="mr-1">mdi-lightbulb-on-outline</v-icon>
+					<v-icon size="14" color="primary" class="me-1">mdi-lightbulb-on-outline</v-icon>
 					{{ __("Tip: Monitor slow queries and table size for optimal performance.") }}
 				</div>
 				<div class="db-tooltip-explanation mt-2 flex items-center">
-					<v-icon size="14" color="info" class="mr-1">mdi-database</v-icon>
+					<v-icon size="14" color="info" class="me-1">mdi-database</v-icon>
 					{{ __("Database health affects overall system speed and reliability.") }}
 				</div>
 			</div>

--- a/posawesome/public/js/posapp/components/navbar/NavbarDrawer.vue
+++ b/posawesome/public/js/posapp/components/navbar/NavbarDrawer.vue
@@ -144,7 +144,7 @@ export default {
 
 /* Styling for the company name text within the drawer header */
 .drawer-company {
-	margin-left: 12px;
+	margin-inline-start: 12px;
 	flex: 1;
 	font-weight: 500;
 	font-size: 1rem;
@@ -160,7 +160,7 @@ export default {
 
 /* Styling for the title text of navigation drawer list items */
 .drawer-item-title {
-	margin-left: 8px;
+	margin-inline-start: 8px;
 	font-weight: 500;
 	font-size: 0.95rem;
 	color: #000000 !important;

--- a/posawesome/public/js/posapp/components/navbar/NavbarMenu.vue
+++ b/posawesome/public/js/posapp/components/navbar/NavbarMenu.vue
@@ -3,7 +3,7 @@
 		<template #activator="{ props }">
 			<v-btn v-bind="props" color="primary" variant="elevated" class="menu-btn-compact">
 				{{ __("Menu") }}
-				<v-icon end size="16" class="ml-1">mdi-menu-down</v-icon>
+				<v-icon end size="16" class="ms-1">mdi-menu-down</v-icon>
 			</v-btn>
 		</template>
 		<v-card class="menu-card-compact" elevation="12">
@@ -186,7 +186,7 @@
 	<v-dialog v-model="showLanguageDialog" max-width="400" persistent>
 		<v-card>
 			<v-card-title class="text-h6 d-flex align-center">
-				<v-icon start color="primary" class="mr-2">mdi-translate</v-icon>
+				<v-icon start color="primary" class="me-2">mdi-translate</v-icon>
 				{{ __("Select Language") }}
 			</v-card-title>
 
@@ -422,8 +422,8 @@ export default {
 <style scoped>
 /* Compact Menu Button - Better Navbar Integration */
 .menu-btn-compact {
-	margin-left: 8px;
-	margin-right: 4px;
+	margin-inline-start: 8px;
+	margin-inline-end: 4px;
 	padding: 6px 16px;
 	border-radius: 20px;
 	font-weight: 600;
@@ -659,7 +659,7 @@ export default {
 	}
 
 	.menu-btn-compact {
-		margin-left: 6px;
+		margin-inline-start: 6px;
 		padding: 5px 14px;
 		min-width: 85px;
 		height: 34px;

--- a/posawesome/public/js/posapp/components/navbar/ServerUsageGadget.vue
+++ b/posawesome/public/js/posapp/components/navbar/ServerUsageGadget.vue
@@ -9,13 +9,13 @@
 			</template>
 			<div class="cpu-tooltip-content">
 				<div class="cpu-tooltip-title">
-					<v-icon size="16" color="primary" class="mr-1">mdi-server</v-icon>
+					<v-icon size="16" color="primary" class="me-1">mdi-server</v-icon>
 					{{ __("Server Health") }}
 				</div>
 				<v-divider class="my-2" />
 				<div class="cpu-tooltip-section-title mb-1">{{ __("Server Metrics") }}</div>
 				<div class="cpu-tooltip-peak mb-1">
-					<v-icon size="14" color="success" class="mr-1">mdi-arrow-up-bold</v-icon>
+					<v-icon size="14" color="success" class="me-1">mdi-arrow-up-bold</v-icon>
 					{{ __("Peak:") }}
 					<b>{{ peakLag.toFixed(1) }} ms</b>
 					({{ peakPercent }}%)
@@ -38,11 +38,11 @@
 					</svg>
 				</div>
 				<div class="cpu-tooltip-detail">
-					<v-icon size="14" color="primary" class="mr-1">mdi-chip</v-icon>
+					<v-icon size="14" color="primary" class="me-1">mdi-chip</v-icon>
 					{{ __("Current Event Loop Lag:") }} <b>{{ cpuLag.toFixed(1) }}</b> ms
 				</div>
 				<div v-if="cpuLag >= 80" class="cpu-tooltip-warning">
-					<v-icon size="14" color="error" class="mr-1">mdi-alert</v-icon>
+					<v-icon size="14" color="error" class="me-1">mdi-alert</v-icon>
 					{{ __("Warning: High lag may indicate heavy processing or browser slowness.") }}
 				</div>
 				<div v-if="serverLoading" class="cpu-tooltip-detail">
@@ -51,18 +51,18 @@
 				<div v-else-if="serverError" class="cpu-tooltip-warning">{{ serverError }}</div>
 				<div v-else>
 					<div class="cpu-tooltip-detail">
-						<v-icon size="14" color="primary" class="mr-1">mdi-chip</v-icon>
+						<v-icon size="14" color="primary" class="me-1">mdi-chip</v-icon>
 						{{ __("Server CPU Usage:") }}
 						<b>{{ serverCpu !== null ? serverCpu.toFixed(1) + "%" : "N/A" }}</b>
-						<span class="ml-2"
+						<span class="ms-2"
 							>{{ __("Peak Server:") }} <b>{{ serverPeak.toFixed(1) }}%</b></span
 						>
 					</div>
 					<div class="cpu-tooltip-detail">
-						<v-icon size="14" color="primary" class="mr-1">mdi-memory</v-icon>
+						<v-icon size="14" color="primary" class="me-1">mdi-memory</v-icon>
 						{{ __("Server Memory Usage:") }}
 						<b>{{ serverMemory !== null ? serverMemory.toFixed(1) + "%" : "N/A" }}</b>
-						<span class="ml-2"
+						<span class="ms-2"
 							>{{ __("Peak Memory:") }} <b>{{ serverMemoryPeak.toFixed(1) }}%</b></span
 						>
 					</div>
@@ -81,48 +81,48 @@
 						}}</span>
 					</div>
 					<div class="cpu-tooltip-detail">
-						<v-icon size="14" color="primary" class="mr-1">mdi-database</v-icon>
+						<v-icon size="14" color="primary" class="me-1">mdi-database</v-icon>
 						{{ __("Total:") }} <b>{{ formatBytes(memoryTotal) }}</b>
-						<span class="ml-2"
+						<span class="ms-2"
 							>{{ __("Used:") }} <b>{{ formatBytes(memoryUsed) }}</b></span
 						>
-						<span class="ml-2"
+						<span class="ms-2"
 							>{{ __("Available:") }} <b>{{ formatBytes(memoryAvailable) }}</b></span
 						>
 					</div>
 					<div class="cpu-tooltip-detail">
-						<v-icon size="14" color="primary" class="mr-1">mdi-timer-outline</v-icon>
+						<v-icon size="14" color="primary" class="me-1">mdi-timer-outline</v-icon>
 						{{ __("Server Uptime:") }} <b>{{ formatUptime(serverUptime) }}</b>
 					</div>
 				</div>
 				<v-divider class="my-2" />
 				<div class="cpu-tooltip-section-title mb-1">{{ __("Client Metrics") }}</div>
 				<div class="cpu-tooltip-detail">
-					<v-icon size="14" color="primary" class="mr-1">mdi-monitor</v-icon>
+					<v-icon size="14" color="primary" class="me-1">mdi-monitor</v-icon>
 					{{ __("Client CPU Lag:") }} <b>{{ cpuLag.toFixed(1) }}</b> ms
 				</div>
 				<div class="cpu-tooltip-detail">
-					<v-icon size="14" color="primary" class="mr-1">mdi-memory</v-icon>
+					<v-icon size="14" color="primary" class="me-1">mdi-memory</v-icon>
 					{{ __("Client Memory Usage:") }} <b>{{ formatBytes(memoryUsage) }}</b>
 				</div>
 				<div class="cpu-tooltip-detail">
-					<v-icon size="14" color="primary" class="mr-1">mdi-chip</v-icon>
+					<v-icon size="14" color="primary" class="me-1">mdi-chip</v-icon>
 					{{ __("CPU Cores:") }} <b>{{ device.cores }}</b>
-					<span v-if="device.gbMemory" class="ml-2"
+					<span v-if="device.gbMemory" class="ms-2"
 						>{{ __("Device Memory:") }} <b>{{ device.gbMemory }} GB</b></span
 					>
 				</div>
 				<v-divider class="my-2" />
 				<div class="cpu-tooltip-tip mt-2">
-					<v-icon size="14" color="primary" class="mr-1">mdi-lightbulb-on-outline</v-icon>
+					<v-icon size="14" color="primary" class="me-1">mdi-lightbulb-on-outline</v-icon>
 					{{ __("Tip: Close unused tabs or apps to reduce lag.") }}
 				</div>
 				<div class="cpu-tooltip-explanation mt-2">
-					<v-icon size="14" color="info" class="mr-1">mdi-chip</v-icon>
+					<v-icon size="14" color="info" class="me-1">mdi-chip</v-icon>
 					{{ __("Event-loop lag measures how busy your browser is. Lower is better.") }}
 				</div>
 				<div class="cpu-tooltip-action mt-2">
-					<v-icon size="14" class="mr-1">mdi-refresh</v-icon>
+					<v-icon size="14" class="me-1">mdi-refresh</v-icon>
 					{{ __("Updates automatically") }}
 				</div>
 			</div>
@@ -275,7 +275,7 @@ const peakPercent = computed(() => Math.round(Math.min(peakLag.value, 100)));
 	background: #e3f2fd;
 	border-radius: 4px;
 	overflow: hidden;
-	margin-right: 6px;
+	margin-inline-end: 6px;
 }
 .cpu-bar-fill {
 	height: 100%;
@@ -346,7 +346,7 @@ const peakPercent = computed(() => Math.round(Math.min(peakLag.value, 100)));
 	width: 10px;
 	height: 10px;
 	border-radius: 50%;
-	margin-right: 4px;
+	margin-inline-end: 4px;
 }
 .legend-dot.client {
 	background: #4caf50;

--- a/posawesome/public/js/posapp/components/navbar/StatusIndicator.vue
+++ b/posawesome/public/js/posapp/components/navbar/StatusIndicator.vue
@@ -183,7 +183,7 @@ export default {
 	align-items: center;
 	gap: 8px;
 	/* Reduced gap */
-	margin-right: 8px;
+	margin-inline-end: 8px;
 	/* Reduced margin */
 }
 
@@ -236,7 +236,7 @@ export default {
 	}
 
 	.status-section-enhanced {
-		margin-right: 4px;
+		margin-inline-end: 4px;
 		/* Further reduced for mobile */
 	}
 }


### PR DESCRIPTION
## Summary
- replace `mr-*` and `ml-*` classes with `me-*`/`ms-*`
- use `margin-inline-start`/`margin-inline-end` instead of `margin-left`/`margin-right`
- ensure navbar gadgets rely on logical spacing utilities

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a37638848832990cabb9980d19b65