### PR TITLE
refactor: add rtl-friendly css in POS components

### DIFF
--- a/posawesome/public/js/posapp/components/pos/CameraScanner.vue
+++ b/posawesome/public/js/posapp/components/pos/CameraScanner.vue
@@ -2,9 +2,9 @@
 	<v-dialog v-model="scannerDialog" max-width="600px" persistent="false">
 		<v-card>
 			<v-card-title class="text-h5 text-primary d-flex align-center">
-				<v-icon class="mr-2" size="large">mdi-camera</v-icon>
+                                <v-icon class="me-2" size="large">mdi-camera</v-icon>
 				{{ __("Scan QR Code/Barcode") }}
-				<v-chip class="ml-2" size="small" color="primary">
+                                <v-chip class="ms-2" size="small" color="primary">
 					{{ scanType === "Both" ? "Auto Detect" : scanType }}
 				</v-chip>
 				<v-spacer></v-spacer>
@@ -131,23 +131,23 @@
 }
 
 .scanning-overlay {
-	position: absolute;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	pointer-events: none;
-	z-index: 10;
+        position: absolute;
+        top: 0;
+        inset-inline-start: 0;
+        inset-inline-end: 0;
+        bottom: 0;
+        pointer-events: none;
+        z-index: 10;
 }
 
 .scan-line {
-	position: absolute;
-	top: 50%;
-	left: 10%;
-	right: 10%;
-	height: 2px;
-	background: linear-gradient(90deg, transparent, #4caf50, transparent);
-	animation: scan 2s linear infinite;
+        position: absolute;
+        top: 50%;
+        inset-inline-start: 10%;
+        inset-inline-end: 10%;
+        height: 2px;
+        background: linear-gradient(90deg, transparent, #4caf50, transparent);
+        animation: scan 2s linear infinite;
 }
 
 @keyframes scan {
@@ -161,11 +161,11 @@
 }
 
 .scan-corners {
-	position: absolute;
-	top: 20%;
-	left: 20%;
-	right: 20%;
-	bottom: 20%;
+        position: absolute;
+        top: 20%;
+        inset-inline-start: 20%;
+        inset-inline-end: 20%;
+        bottom: 20%;
 }
 
 .corner {
@@ -176,31 +176,31 @@
 }
 
 .corner.top-left {
-	top: 0;
-	left: 0;
-	border-right: none;
-	border-bottom: none;
+        top: 0;
+        inset-inline-start: 0;
+        border-inline-end: none;
+        border-bottom: none;
 }
 
 .corner.top-right {
-	top: 0;
-	right: 0;
-	border-left: none;
-	border-bottom: none;
+        top: 0;
+        inset-inline-end: 0;
+        border-inline-start: none;
+        border-bottom: none;
 }
 
 .corner.bottom-left {
-	bottom: 0;
-	left: 0;
-	border-right: none;
-	border-top: none;
+        bottom: 0;
+        inset-inline-start: 0;
+        border-inline-end: none;
+        border-top: none;
 }
 
 .corner.bottom-right {
-	bottom: 0;
-	right: 0;
-	border-left: none;
-	border-top: none;
+        bottom: 0;
+        inset-inline-end: 0;
+        border-inline-start: none;
+        border-top: none;
 }
 
 .status-messages {

--- a/posawesome/public/js/posapp/components/pos/Customer.vue
+++ b/posawesome/public/js/posapp/components/pos/Customer.vue
@@ -89,13 +89,13 @@
 
 <style scoped>
 .customer-input-wrapper {
-	width: 100%;
-	max-width: 100%;
-	padding-right: 1.5rem;
-	/* Elegant space at the right edge */
-	box-sizing: border-box;
-	display: flex;
-	flex-direction: column;
+        width: 100%;
+        max-width: 100%;
+        padding-inline-end: 1.5rem;
+        /* Elegant space at the right edge */
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
 }
 
 .customer-autocomplete {

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -1217,10 +1217,10 @@ export default {
 
 /* Style for balance value text */
 :deep(.balance-value) {
-	font-size: 1.5rem;
-	font-weight: bold;
-	color: var(--primary-start);
-	margin-left: var(--dynamic-xs);
+        font-size: 1.5rem;
+        font-weight: bold;
+        color: var(--primary-start);
+        margin-inline-start: var(--dynamic-xs);
 }
 
 /* Red border and label for return mode card */
@@ -1234,16 +1234,16 @@ export default {
 
 /* Label for return mode card */
 .return-mode::before {
-	content: "RETURN";
-	position: absolute;
-	top: 0;
-	right: 0;
-	background-color: rgb(var(--v-theme-error));
-	color: white;
-	padding: 4px 12px;
-	font-weight: bold;
-	border-bottom-left-radius: 8px;
-	z-index: 1;
+        content: "RETURN";
+        position: absolute;
+        top: 0;
+        inset-inline-end: 0;
+        background-color: rgb(var(--v-theme-error));
+        color: white;
+        padding: 4px 12px;
+        font-weight: bold;
+        border-end-start-radius: 8px;
+        z-index: 1;
 }
 
 /* Dynamic padding for responsive layout */
@@ -1283,15 +1283,15 @@ export default {
 }
 
 .column-selector-container {
-	display: flex;
-	justify-content: flex-end;
-	padding: 8px 16px;
-	background-color: var(--surface-secondary);
-	border-radius: 8px 8px 0 0;
-	position: absolute;
-	top: 0;
-	right: 0;
-	transform: translateY(-100%);
+        display: flex;
+        justify-content: flex-end;
+        padding: 8px 16px;
+        background-color: var(--surface-secondary);
+        border-radius: 8px 8px 0 0;
+        position: absolute;
+        top: 0;
+        inset-inline-end: 0;
+        transform: translateY(-100%);
 }
 
 :deep([data-theme="dark"]) .column-selector-container,

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -2165,7 +2165,7 @@ export default {
           <div class="item-option p-3 mb-2 border rounded cursor-pointer" data-item-index="${index}" style="border: 1px solid #ddd; cursor: pointer;">
             <div class="d-flex align-items-center">
               <img src="${item.image || "/assets/posawesome/js/posapp/components/pos/placeholder-image.png"}"
-                   style="width: 50px; height: 50px; object-fit: cover; margin-right: 15px;" />
+                   style="width: 50px; height: 50px; object-fit: cover; margin-inline-end: 15px;" />
               <div>
                 <div class="font-weight-bold">${item.item_name}</div>
                 <div class="text-muted small">${item.item_code}</div>

--- a/posawesome/public/js/posapp/components/pos/ItemsTable.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsTable.vue
@@ -342,7 +342,7 @@
 											class="change-price-btn"
 											@click.stop="changePriceListRate(item)"
 										>
-											<v-icon size="small" class="mr-1">mdi-pencil</v-icon>
+                                                                                        <v-icon size="small" class="me-1">mdi-pencil</v-icon>
 											{{ __("Change Price") }}
 										</v-btn>
 									</div>
@@ -833,8 +833,8 @@ export default {
 }
 
 .action-panel-icon {
-	margin-right: 8px;
-	color: var(--primary-color, #1976d2);
+        margin-inline-end: 8px;
+        color: var(--primary-color, #1976d2);
 }
 
 .action-panel-title {
@@ -874,9 +874,9 @@ export default {
 }
 
 .item-action-btn .action-label {
-	margin-left: 8px;
-	font-weight: 500;
-	display: none;
+        margin-inline-start: 8px;
+        font-weight: 500;
+        display: none;
 }
 
 @media (min-width: 600px) {
@@ -1022,21 +1022,21 @@ export default {
 }
 
 .section-header::after {
-	content: "";
-	position: absolute;
-	bottom: -2px;
-	left: 0;
-	width: 40px;
-	height: 2px;
-	background: linear-gradient(90deg, var(--primary-color, #1976d2), transparent);
+        content: "";
+        position: absolute;
+        bottom: -2px;
+        inset-inline-start: 0;
+        width: 40px;
+        height: 2px;
+        background: linear-gradient(90deg, var(--primary-color, #1976d2), transparent);
 }
 
 .section-icon {
-	margin-right: 10px;
-	color: var(--primary-color, #1976d2);
-	background: rgba(25, 118, 210, 0.1);
-	padding: 6px;
-	border-radius: 8px;
+        margin-inline-end: 10px;
+        color: var(--primary-color, #1976d2);
+        background: rgba(25, 118, 210, 0.1);
+        padding: 6px;
+        border-radius: 8px;
 }
 
 :deep([data-theme="dark"]) .section-icon,
@@ -1113,14 +1113,14 @@ export default {
 }
 
 .currency-symbol {
-	opacity: 0.7;
-	margin-right: 2px;
-	font-size: 0.85em;
+        opacity: 0.7;
+        margin-inline-end: 2px;
+        font-size: 0.85em;
 }
 
 .amount-value {
-	font-weight: 500;
-	text-align: left;
+        font-weight: 500;
+        text-align: start;
 }
 
 /* Drag and drop styles */

--- a/posawesome/public/js/posapp/components/pos/Mpesa-Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Mpesa-Payments.vue
@@ -27,9 +27,9 @@
                                                         clearable
                                                         class="mx-4"
                                                 ></v-text-field>
-						<v-btn variant="text" class="ml-2" color="primary" theme="dark" @click="search">{{
-							__("Search")
-						}}</v-btn>
+                                                <v-btn variant="text" class="ms-2" color="primary" theme="dark" @click="search">{{
+                                                        __("Search")
+                                                }}</v-btn>
 					</v-row>
 					<v-row>
 						<v-col cols="12" class="pa-1" v-if="dialog_data">

--- a/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
+++ b/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
@@ -573,11 +573,11 @@ export default {
 		padding: 12px;
 	}
 
-	.action-btn-compact {
-		margin-left: 4px;
-		padding: 6px 10px;
-		min-width: 60px;
-	}
+        .action-btn-compact {
+                margin-inline-start: 4px;
+                padding: 6px 10px;
+                min-width: 60px;
+        }
 }
 
 /* Animation Effects */

--- a/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
+++ b/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
@@ -29,7 +29,7 @@
 				class="flex-grow-1 sleek-field"
 				@update:model-value="onPriceListUpdate"
 			/>
-			<div v-if="pos_profile.posa_show_customer_balance" class="balance-field ml-3">
+                        <div v-if="pos_profile.posa_show_customer_balance" class="balance-field ms-3">
 				<strong>{{ __("Customer Balance") }}:</strong>
 				<span class="balance-value">{{ formatCurrency(customer_balance) }}</span>
 			</div>
@@ -172,6 +172,6 @@ export default {
 
 /* Increase right padding to accommodate both icons */
 .posting-date-input :deep(.dp__input) {
-	padding-right: calc(30px + var(--dp-input-icon-padding));
+        padding-inline-end: calc(30px + var(--dp-input-icon-padding));
 }
 </style>

--- a/posawesome/public/js/posapp/components/pos/Returns.vue
+++ b/posawesome/public/js/posapp/components/pos/Returns.vue
@@ -148,28 +148,28 @@
 					<!-- Action buttons -->
 					<v-row class="mt-2 mb-2">
 						<v-spacer></v-spacer>
-						<v-btn
-							variant="text"
-							class="ml-2"
-							color="primary"
-							theme="dark"
-							@click="search_invoices"
-						>
+                                                <v-btn
+                                                        variant="text"
+                                                        class="ms-2"
+                                                        color="primary"
+                                                        theme="dark"
+                                                        @click="search_invoices"
+                                                >
 							<v-icon left>mdi-magnify</v-icon>
 							{{ __("Search") }}
 						</v-btn>
-						<v-btn variant="text" class="ml-2" color="warning" theme="dark" @click="clear_search">
+                                                <v-btn variant="text" class="ms-2" color="warning" theme="dark" @click="clear_search">
 							<v-icon left>mdi-refresh</v-icon>
 							{{ __("Clear") }}
 						</v-btn>
-						<v-btn
-							v-if="pos_profile.posa_allow_return_without_invoice == 1"
-							variant="text"
-							class="ml-2"
-							color="secondary"
-							theme="dark"
-							@click="return_without_invoice"
-						>
+                                                <v-btn
+                                                        v-if="pos_profile.posa_allow_return_without_invoice == 1"
+                                                        variant="text"
+                                                        class="ms-2"
+                                                        color="secondary"
+                                                        theme="dark"
+                                                        @click="return_without_invoice"
+                                                >
 							{{ __("Return without Invoice") }}
 						</v-btn>
 					</v-row>

--- a/posawesome/public/js/posapp/components/pos/SalesOrders.vue
+++ b/posawesome/public/js/posapp/components/pos/SalesOrders.vue
@@ -21,14 +21,14 @@
                                                                 clearable
                                                                 class="mx-4"
                                                         ></v-text-field>
-							<v-btn
-								variant="text"
-								class="ml-2"
-								color="primary"
-								theme="dark"
-								@click="search_orders"
-								>{{ __("Search") }}</v-btn
-							>
+                                                        <v-btn
+                                                                variant="text"
+                                                                class="ms-2"
+                                                                color="primary"
+                                                                theme="dark"
+                                                                @click="search_orders"
+                                                                >{{ __("Search") }}</v-btn
+                                                        >
 						</v-row>
 						<v-row no-gutters>
 							<v-col cols="12" class="pa-1">

--- a/posawesome/public/js/posapp/utils/rtl.js
+++ b/posawesome/public/js/posapp/utils/rtl.js
@@ -1,0 +1,3 @@
+/* global frappe */
+
+export const isRTL = () => frappe.utils.is_rtl();


### PR DESCRIPTION
## Summary
- replace left/right CSS with logical inline properties across POS components
- swap `ml-*` and `mr-*` utility classes with `ms-*` and `me-*`
- add `isRTL` helper for future conditional direction logic

## Testing
- `npx vite build`
- `npm test` *(fails: Missing script "test")*
- `npx eslint posawesome/public/js/posapp/components/pos posawesome/public/js/posapp/utils/rtl.js` *(fails: multiple "no-undef" errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a37669c30832984a63cd9c14078e2