### PR TITLE
Ensure language direction sync between HTML and Vuetify

### DIFF
--- a/posawesome/public/js/posapp/components/navbar/NavbarMenu.vue
+++ b/posawesome/public/js/posapp/components/navbar/NavbarMenu.vue
@@ -210,7 +210,11 @@
 						<v-list-item v-bind="props">
 							<template #prepend>
 								<v-icon :color="item.raw.code === currentLanguage ? 'primary' : 'grey'">
-									{{ item.raw.code === currentLanguage ? 'mdi-check-circle' : 'mdi-circle-outline' }}
+									{{
+										item.raw.code === currentLanguage
+											? "mdi-check-circle"
+											: "mdi-circle-outline"
+									}}
 								</v-icon>
 							</template>
 							<v-list-item-title>
@@ -230,19 +234,14 @@
 					density="compact"
 					class="mt-3"
 				>
-					{{ __("Language will be changed to") }}: 
+					{{ __("Language will be changed to") }}:
 					<strong>{{ selectedLanguageName }}</strong>
 				</v-alert>
 			</v-card-text>
 
 			<v-card-actions class="pa-4 pt-0">
 				<v-spacer />
-				<v-btn
-					color="grey"
-					variant="text"
-					@click="closeLanguageDialog"
-					:disabled="changing"
-				>
+				<v-btn color="grey" variant="text" @click="closeLanguageDialog" :disabled="changing">
 					{{ __("Cancel") }}
 				</v-btn>
 				<v-btn
@@ -274,6 +273,7 @@
 </template>
 
 <script>
+/* global frappe */
 const FALLBACK_LANGUAGES = [
 	{ code: "en", name: "English", native_name: "English" },
 	{ code: "ar", name: "العربية", native_name: "العربية" },
@@ -312,7 +312,7 @@ export default {
 			return this.selectedLanguage !== this.currentLanguage && !this.changing;
 		},
 		selectedLanguageName() {
-			const lang = this.availableLanguages.find(l => l.code === this.selectedLanguage);
+			const lang = this.availableLanguages.find((l) => l.code === this.selectedLanguage);
 			return lang?.name || this.selectedLanguage.toUpperCase();
 		},
 	},
@@ -329,24 +329,33 @@ export default {
 			this.changing = true;
 			try {
 				const response = await frappe.call({
-					method: 'posawesome.posawesome.api.utilities.set_current_user_language',
-					args: { lang_code: this.selectedLanguage }
+					method: "posawesome.posawesome.api.utilities.set_current_user_language",
+					args: { lang_code: this.selectedLanguage },
 				});
 
 				const result = response?.message || response;
-				
+
 				if (result?.success) {
 					this.currentLanguage = this.selectedLanguage;
-					
+
 					if (window.frappe && window.frappe.boot) {
 						window.frappe.boot.lang = this.selectedLanguage;
 					}
-					
+
+					if (window.frappe?.utils) {
+						const dir = frappe.utils.is_rtl() ? "rtl" : "ltr";
+						localStorage.setItem("lang_dir", dir);
+						document.documentElement.dir = dir;
+						if (this.$vuetify?.locale?.isRtl) {
+							this.$vuetify.locale.isRtl.value = dir === "rtl";
+						}
+					}
+
 					this.showNotification("Language changed successfully! Reloading...", "success");
 					this.closeLanguageDialog();
-					
-					this.$emit('clear-cache');
-					
+
+					this.$emit("clear-cache");
+
 					setTimeout(() => {
 						window.location.reload();
 					}, 2000);
@@ -355,7 +364,10 @@ export default {
 					this.showNotification(errorMsg, "error");
 				}
 			} catch (error) {
-				this.showNotification(`Failed to change language: ${error.message || 'Unknown error'}`, "error");
+				this.showNotification(
+					`Failed to change language: ${error.message || "Unknown error"}`,
+					"error",
+				);
 			} finally {
 				this.changing = false;
 			}
@@ -365,11 +377,11 @@ export default {
 			this.loading = true;
 			try {
 				const response = await frappe.call({
-					method: 'posawesome.posawesome.api.utilities.get_current_user_language'
+					method: "posawesome.posawesome.api.utilities.get_current_user_language",
 				});
-				
+
 				const result = response?.message || response;
-				
+
 				if (result?.success) {
 					Object.assign(this, {
 						availableLanguages: result.available_languages,
@@ -408,7 +420,7 @@ export default {
 	},
 	emits: [
 		"close-shift",
-		"print-last-invoice", 
+		"print-last-invoice",
 		"sync-invoices",
 		"toggle-offline",
 		"clear-cache",

--- a/posawesome/public/js/posapp/posapp.js
+++ b/posawesome/public/js/posapp/posapp.js
@@ -1,3 +1,4 @@
+/* global frappe, $ */
 import { createVuetify } from "vuetify";
 import { createApp } from "vue";
 import Dexie from "dexie/dist/dexie.mjs";
@@ -24,11 +25,13 @@ frappe.PosApp.posapp = class {
 	}
 	make_body() {
 		this.$el = this.$parent.find(".main-section");
+		const dir = frappe.utils.is_rtl() ? "rtl" : "ltr";
+		document.documentElement.dir = dir;
 		const vuetify = createVuetify({
 			components,
 			directives,
 			locale: {
-				rtl: frappe.utils.is_rtl(),
+				rtl: dir === "rtl",
 			},
 			theme: {
 				defaultTheme: "light",


### PR DESCRIPTION
## Summary
- Set `<html>` `dir` attribute based on `frappe.utils.is_rtl()` during POS app creation and pass direction to Vuetify
- When changing language in Navbar, update direction, persist it in `localStorage`, and sync Vuetify's RTL flag before reload

## Testing
- `npx eslint posawesome/public/js/posapp/posapp.js posawesome/public/js/posapp/components/navbar/NavbarMenu.vue`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a37688a408329885855f5d4e61074