### PR TITLE
Fix POS Profile document cache clearing

### DIFF
--- a/posawesome/posawesome/api/utilities.py
+++ b/posawesome/posawesome/api/utilities.py
@@ -780,7 +780,7 @@ def set_pos_profile_language_and_number_system(
 
         # Clear caches
         frappe.clear_cache(doctype="POS Profile")
-        frappe.clear_cache(doctype="POS Profile", name=pos_profile)
+        frappe.clear_document_cache("POS Profile", pos_profile)
 
         return {
             "success": True,


### PR DESCRIPTION
## Summary
- Use `frappe.clear_document_cache` when updating POS Profile language or number system

## Testing
- `ruff check posawesome/posawesome/api/utilities.py`
- `pytest` *(fails: No module named 'frappe')*


------
https://chatgpt.com/codex/tasks/task_e_68a1e805f270832990fb2510078944b6