### PR TITLE
fix: use lowercase number format codes

### DIFF
--- a/posawesome/public/js/posapp/components/navbar/NavbarMenu.vue
+++ b/posawesome/public/js/posapp/components/navbar/NavbarMenu.vue
@@ -373,12 +373,12 @@ export default {
 				(this.selectedLanguage === 'ar' && this.selectedNumberFormat !== this.currentNumberFormat)) && 
 				!this.changing;
 		},
-		availableNumberFormats() {
-			return [
-				{ code: 'Western', name: this.numberFormatNames.western },
-				{ code: 'Arabic', name: this.numberFormatNames.arabic }
-			];
-		},
+                availableNumberFormats() {
+                        return [
+                                { code: 'western', name: this.numberFormatNames.western },
+                                { code: 'arabic', name: this.numberFormatNames.arabic }
+                        ];
+                },
 	},
 	watch: {
 		selectedLanguage(newLang) {


### PR DESCRIPTION
## Summary
- use lowercase codes for number format options in navbar menu

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a1e81956708329bf461982f048706c