### PR TITLE
Normalize POS number system values

### DIFF
--- a/posawesome/posawesome/api/utilities.py
+++ b/posawesome/posawesome/api/utilities.py
@@ -726,7 +726,8 @@ def get_pos_profile_number_system(pos_profile: str):
     """Return the 'posa_number_system' setting for the given POS Profile."""
     if not pos_profile or not pos_profile.strip():
         return None
-    return frappe.get_cached_value("POS Profile", pos_profile, "posa_number_system")
+    value = frappe.get_cached_value("POS Profile", pos_profile, "posa_number_system")
+    return value.title() if value else None
 
 
 @frappe.whitelist()
@@ -769,7 +770,7 @@ def set_pos_profile_language_and_number_system(
                     "success": False,
                     "message": f"Number system '{number_system}' is not supported. Available: {', '.join(valid_number_systems)}",
                 }
-            updates["posa_number_system"] = number_system
+            updates["posa_number_system"] = normalized_number_system
 
         if not updates:
             return {"success": False, "message": "No values provided to update"}
@@ -875,6 +876,8 @@ def get_pos_profile_settings(pos_profile=None):
         current_number_system = frappe.get_cached_value(
             "POS Profile", pos_profile, "posa_number_system"
         )
+        if current_number_system:
+            current_number_system = current_number_system.title()
 
         # Get available options
         available_languages = get_available_languages()


### PR DESCRIPTION
## Summary
- normalize number system values when updating POS profiles
- ensure retrieved POS profile number system is in title case

## Testing
- `ruff check posawesome/posawesome/api/utilities.py | tail -n 20`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68a1e81820cc832980c4a0f2aedef551